### PR TITLE
Update brownie requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ pip install -r requirements.txt
 
 #install openzeppelin library, to import from .sol (ignore FileExistsErrors)
 brownie pm install OpenZeppelin/openzeppelin-contracts@4.0.0
-brownie pm install OpenZeppelin/openzeppelin-contracts@2.1.1
 ```
 
 # Main Usage: CLI

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # VestingWallet CLI
 
-CLI for OpenZeppelin [VestingWallet](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/27f8609ac949fb3a0b24b8194e6ff3eb2dcd0f67/contracts/token/TokenTimelock.sol) contract. 
+CLI for OpenZeppelin [VestingWallet](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/27f8609ac949fb3a0b24b8194e6ff3eb2dcd0f67/contracts/token/TokenTimelock.sol) contract.
 
 Functionality is via `vw` tool:
+
 ```text
 vw fund - send funds with vesting wallet
 vw batch - batch send funds via vesting wallets
@@ -14,13 +15,15 @@ vw walletinfo - info about a vesting wallet
 ```
 
 Other features:
+
 - Via brownie, easy to interact with contract in console
 - Thorough unit tests
 
 Potential future features:
+
 - CLI currently supports fixed lock time ("cliff of x"); could pull up contract functionality for linear vesting
 - CLI currently supports ERC20; could pull up contract functionality for ETH
-- Usage requires `git clone` etc. Could add to pip, or make it a fully independent tool 
+- Usage requires `git clone` etc. Could add to pip, or make it a fully independent tool
 
 # Installation
 
@@ -35,7 +38,7 @@ Now, open a new terminal and:
 
 ```console
 #clone repo
-git clone https://github.com/oceanprotocol/vw-cli.git 
+git clone https://github.com/oceanprotocol/vw-cli.git
 cd vw-cli
 
 #create a virtual environment
@@ -49,21 +52,25 @@ pip install -r requirements.txt
 
 #install openzeppelin library, to import from .sol (ignore FileExistsErrors)
 brownie pm install OpenZeppelin/openzeppelin-contracts@4.0.0
+brownie pm install OpenZeppelin/openzeppelin-contracts@2.1.1
 ```
 
 # Main Usage: CLI
 
 First, compile. From terminal:
+
 ```console
 brownie compile
 ```
 
 The `vw` CLI needs needs a chain to persist between commands: either a remote chain, or a separate local process (vs one auto-started for each command). To run a local chain, open a new terminal and:
+
 ```
 ganache-cli
 ```
 
 Then, in the main terminal:
+
 ```console
 #add pwd to bash path
 export PATH=$PATH:.
@@ -74,12 +81,12 @@ vw
 
 **Then, simply follow the usage directions:)**
 
-
 # Other Usage
 
 ## Running Tests
 
 In terminal:
+
 ```console
 #run one test
 brownie test tests/test_Simpletoken.py::test_transfer
@@ -94,11 +101,13 @@ brownie test
 ## Brownie Console
 
 From terminal:
+
 ```console
 brownie console
 ```
 
 In brownie console:
+
 ```python
 >>> t = Simpletoken.deploy("TEST", "Test Token", 18, 100, {'from': accounts[0]})
 Transaction sent: 0x3f113379b70d00041068b27733c37c2977354d8c70cb0b30b0af3087fca9c2b8
@@ -106,13 +115,14 @@ Transaction sent: 0x3f113379b70d00041068b27733c37c2977354d8c70cb0b30b0af3087fca9
   Simpletoken.constructor confirmed   Block: 1   Gas used: 551616 (8.21%)
   Simpletoken deployed at: 0x3194cBDC3dbcd3E11a07892e7bA5c3394048Cc87
 
->>> t.symbol()                                                                                                                                                                                              
+>>> t.symbol()
 'TEST'
 ```
 
 ## Simple Test Script
 
 An example of a script. You can add more. From terminal:
+
 ```console
 ./scripts/run_vesting_wallet.py
 ```

--- a/contracts/Simpletoken.sol
+++ b/contracts/Simpletoken.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.7;
 // SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
 
-import "OpenZeppelin/openzeppelin-contracts@2.1.1/contracts/math/SafeMath.sol";
+import "./SafeMath.sol";
 
 contract Simpletoken {
 


### PR DESCRIPTION
Fixes #1 

Changes proposed in this PR:

- Instead of downloading the entire OpenZeppelin2.1.1 package I decided to import the already existing SafeMath.sol https://github.com/oceanprotocol/vw-cli/blob/d7a723a1476ef3d47f0c5d8da12b362847b8286f/contracts/SafeMath.sol
